### PR TITLE
Improve SEO with meta tags and sitemap

### DIFF
--- a/about/index.html
+++ b/about/index.html
@@ -4,6 +4,17 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>About Freemaged</title>
+    <meta name="description" content="Learn how Freemaged keeps your image editing private and offline.">
+    <meta name="keywords" content="privacy, image editor, freemaged, open source">
+    <link rel="canonical" href="https://freemaged.com/about/">
+    <meta property="og:title" content="About Freemaged">
+    <meta property="og:description" content="Find out why Freemaged is a privacy-first browser image editor.">
+    <meta property="og:url" content="https://freemaged.com/about/">
+    <meta property="og:type" content="article">
+    <meta property="og:image" content="https://freemaged.com/fav.ico">
+    <meta name="twitter:card" content="summary">
+    <meta name="twitter:title" content="About Freemaged">
+    <meta name="twitter:description" content="Learn how Freemaged respects your privacy when editing images.">
     <link rel="icon" href="../fav.ico" type="image/x-icon">
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/index.html
+++ b/index.html
@@ -4,6 +4,17 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Freemaged v1.0</title>
+    <meta name="description" content="Freemaged is a free, privacy focused browser image editor that runs entirely in your browser.">
+    <meta name="keywords" content="image editor, online image editor, privacy, open source, freemaged">
+    <link rel="canonical" href="https://freemaged.com/">
+    <meta property="og:title" content="Freemaged - Free Browser Image Editor">
+    <meta property="og:description" content="Edit images privately in your browser with Freemaged.">
+    <meta property="og:url" content="https://freemaged.com/">
+    <meta property="og:type" content="website">
+    <meta property="og:image" content="https://freemaged.com/fav.ico">
+    <meta name="twitter:card" content="summary">
+    <meta name="twitter:title" content="Freemaged - Free Browser Image Editor">
+    <meta name="twitter:description" content="Edit images privately in your browser with Freemaged.">
     <link rel="icon" href="fav.ico" type="image/x-icon">
     <script src="https://cdn.tailwindcss.com"></script>
     <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css" rel="stylesheet">

--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,3 @@
+User-agent: *
+Allow: /
+Sitemap: https://freemaged.com/sitemap.xml

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://freemaged.com/</loc>
+  </url>
+  <url>
+    <loc>https://freemaged.com/about/</loc>
+  </url>
+</urlset>


### PR DESCRIPTION
## Summary
- add Open Graph and Twitter meta tags to pages for social sharing
- include description and keyword meta tags
- provide canonical links
- add `robots.txt` and `sitemap.xml`

## Testing
- `apt-get update` *(fails: repository not signed)

------
https://chatgpt.com/codex/tasks/task_e_687d6b19c4a8832d860fd1b6e62fa04f