### PR TITLE
Improve mobile experience and document version history

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,8 @@ The about page lives in `about/index.html` and describes Freemaged's privacy-foc
 ## Running
 
 No build step is required. Open `index.html` directly in a browser or serve the directory with any static file server.
+
+## Version History
+
+- **v1.1** – Improved SEO with additional meta tags and sitemap support.
+- **v1.2** – Enhanced mobile experience by allowing the tool panel to be hidden on small screens.

--- a/index.html
+++ b/index.html
@@ -25,7 +25,9 @@
 </head>
 <body class="bg-gray-900 text-gray-100 flex flex-col md:flex-row h-screen overflow-hidden">
 
-    <div class="w-full md:w-[21.6rem] bg-gray-800 p-4 shadow-lg control-panel flex flex-col flex-shrink-0 h-[60vh] md:h-screen">
+    <button id="togglePanelBtn" class="md:hidden bg-blue-600 text-white px-3 py-2 m-2 rounded self-end">Hide Tools</button>
+
+    <div id="controlPanel" class="w-full md:w-[21.6rem] bg-gray-800 p-4 shadow-lg control-panel flex flex-col flex-shrink-0 h-[60vh] md:h-screen">
         <div class="flex justify-between items-center mb-4">
             <h1 class="text-2xl font-bold text-blue-400">Freemaged</h1>
             <div class="flex items-center space-x-2">

--- a/js/app.js
+++ b/js/app.js
@@ -19,6 +19,9 @@
         const originalFileSizeEl = document.getElementById('originalFileSize');
         const currentDimensionsEl = document.getElementById('currentDimensions');
 
+        const togglePanelBtn = document.getElementById('togglePanelBtn');
+        const controlPanel = document.getElementById('controlPanel');
+
         // Tabs
         const tabButtons = document.querySelectorAll('.tab-button');
         const tabContents = document.querySelectorAll('.tab-content');
@@ -113,7 +116,15 @@
         // --- INITIALIZATION ---
         disableAllControls(); 
         setupTabs(); 
-        updateQualityVisibility(); 
+        updateQualityVisibility();
+        updatePanelVisibilityForViewport();
+
+        togglePanelBtn.addEventListener('click', () => {
+            controlPanel.classList.toggle('hidden');
+            togglePanelBtn.textContent = controlPanel.classList.contains('hidden') ? 'Show Tools' : 'Hide Tools';
+        });
+
+        window.addEventListener('resize', updatePanelVisibilityForViewport);
 
         // --- UTILITY FUNCTIONS ---
         function showNotification(message, type = 'success', duration = 3000) {
@@ -1457,6 +1468,17 @@
             exportMessage.textContent = finalMessage;
             showNotification(finalMessage, errorCount > 0 ? 'warning' : (successCount > 0 ? 'success': 'info'));
         });
+
+        function updatePanelVisibilityForViewport() {
+            const isDesktop = window.matchMedia('(min-width: 768px)').matches;
+            if (isDesktop) {
+                controlPanel.classList.remove('hidden');
+                togglePanelBtn.classList.add('hidden');
+            } else {
+                togglePanelBtn.classList.remove('hidden');
+                togglePanelBtn.textContent = controlPanel.classList.contains('hidden') ? 'Show Tools' : 'Hide Tools';
+            }
+        }
        
         // --- WINDOW RESIZE ---
         const debouncedRedraw = debounce(() => {


### PR DESCRIPTION
## Summary
- add toggle button to hide/show tool panel on small screens
- show/hide panel automatically depending on viewport size
- document SEO update in v1.1 and mobile improvements in v1.2

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687d94760b60832d82567df227fc78cf